### PR TITLE
fixed path to images

### DIFF
--- a/dialogs/note.js
+++ b/dialogs/note.js
@@ -12,7 +12,7 @@ CKEDITOR.dialog.add( 'noteDialog', function( editor ) {
 						type: 'radio',
 						id: 'notetype',
 						label: editor.lang.note.selectOption,
-						items: [ [ '<img src="/lib/plugins/ckgedit/ckeditor/plugins/note/icons/note_basic.png">', 'basic' ], [ '<img src="/lib/plugins/ckgedit/ckeditor/plugins/note/icons/note_important.png">', 'important' ] , [ '<img src="/lib/plugins/ckgedit/ckeditor/plugins/note/icons/note_tip.png">', 'tip' ] , [ '<img src="/lib/plugins/ckgedit/ckeditor/plugins/note/icons/note_warning.png">', 'warning' ] ],
+						items: [ [ '<img src= "' + DOKU_BASE+ 'lib/plugins/ckgedit/ckeditor/plugins/note/icons/note_basic.png">', 'basic' ], [ '<img src="' + DOKU_BASE+ 'lib/plugins/ckgedit/ckeditor/plugins/note/icons/note_important.png">', 'important' ] , [ '<img src="' + DOKU_BASE+ 'lib/plugins/ckgedit/ckeditor/plugins/note/icons/note_tip.png">', 'tip' ] , [ '<img src="' + DOKU_BASE+ 'lib/plugins/ckgedit/ckeditor/plugins/note/icons/note_warning.png">', 'warning' ] ],
 						style: 'color: black',
 						'default': 'basic',
 					},


### PR DESCRIPTION
Uses DOKU_BASE, otherwise (in my ckgedit) the images fail to load.  Also the instructions could be synched with https://www.dokuwiki.org/plugin:ckgedit:configuration#extra_plugins. But first implement this pull request.

The missing comma was the problem. 