### PR TITLE
enable note text selection from editor

### DIFF
--- a/dialogs/note.js
+++ b/dialogs/note.js
@@ -20,16 +20,27 @@ CKEDITOR.dialog.add( 'noteDialog', function( editor ) {
                         type: 'text',
                         id: 'note',
                         label: editor.lang.note.content,
-                        validate: CKEDITOR.dialog.validate.notEmpty( "Note field cannot be empty." )
+              			'default': ''
                     }
                 ]
             }
         ],
+		// Invoked when the dialog is loaded.
+		onShow: function() {
+			// Get the selection from the editor.    
+		    var text = editor.getSelection().getSelectedText();            
+            if(text) {                          
+                this.getContentElement( 'tab-basic', 'note').disable();
+                this.setValueOf( 'tab-basic', 'note',text);
+            }    
+               else this.text = false;
+		},       
+        
         onOk: function() {
             var dialog = this;
 
-            var note = editor.document.createElement( 'note' );
-            note.setAttribute( 'title', dialog.getValueOf( 'tab-basic', 'note' ) );
+          //    var note = editor.document.createElement( 'note' );  
+          //  note.setAttribute( 'title', dialog.getValueOf( 'tab-basic', 'note' ) );
 			
 			//get the note type
 			var noteTypeValue = dialog.getValueOf( 'tab-basic', 'notetype' );
@@ -42,7 +53,11 @@ CKEDITOR.dialog.add( 'noteDialog', function( editor ) {
 			}
 			
 			//get the note text
-			var noteText = dialog.getValueOf( 'tab-basic', 'note' );
+			var noteText = this.text ? this.text: dialog.getValueOf( 'tab-basic', 'note' );
+            if(!noteText) {
+                alert("Note cannot be left empty");
+                return false;
+            }
 			//insert the note
 			editor.insertText ( noteTypeValue + noteText + '</note>' )
 


### PR DESCRIPTION
The user can select text from editor using mouse, which will then be inserted into the note.  In this case the text box is disabled.  If no text is selected in editor, then text box is enabled for text insertion.